### PR TITLE
feat(form.vue): enhances validation messages with commands or urls to…

### DIFF
--- a/__tests__/input.spec.js
+++ b/__tests__/input.spec.js
@@ -1,7 +1,7 @@
-import { mount } from '@vue/test-utils';
-import Vue from 'vue';
-import Form from '../src/Form.vue';
-import utils from './utils';
+import { mount } from "@vue/test-utils";
+import Vue from "vue";
+import Form from "../src/Form.vue";
+import utils from "./utils";
 
 const questionInput = [
   {
@@ -9,7 +9,7 @@ const questionInput = [
     name: "input",
     message: "An input",
     default: "default input",
-    validate: function (input) {
+    validate: function(input) {
       if (input.length >= 2) {
         return true;
       } else {
@@ -33,7 +33,7 @@ const questionNumber = [
     name: "number",
     message: "A number",
     default: "0"
-  },
+  }
 ];
 
 const questionsConditional = [
@@ -45,8 +45,8 @@ const questionsConditional = [
   {
     type: "input",
     name: "conditional",
-    when: function (answers) {
-      return (answers.condition !== "hide");
+    when: function(answers) {
+      return answers.condition !== "hide";
     }
   },
   {
@@ -70,8 +70,8 @@ const questionsMessageAsFunction = [
   {
     type: "input",
     name: "message",
-    message: function (answers) {
-      return (`${answers.trigger}-message`);
+    message: function(answers) {
+      return `${answers.trigger}-message`;
     }
   }
 ];
@@ -85,8 +85,8 @@ const questionsDefaultAsFunction = [
   {
     type: "input",
     name: "default",
-    default: function (answers) {
-      return (`${answers.trigger}-default`);
+    default: function(answers) {
+      return `${answers.trigger}-default`;
     }
   }
 ];
@@ -103,8 +103,8 @@ const questionsWithApplyDefaultWhenDirty = [
       applyDefaultWhenDirty: true
     },
     name: "default",
-    default: function (answers) {
-      return (`${answers.trigger}-default`);
+    default: function(answers) {
+      return `${answers.trigger}-default`;
     }
   }
 ];
@@ -121,8 +121,8 @@ const questionInputDefaultException = [
     type: "input",
     name: "inputDefaultException",
     message: "An input",
-    default: function () {
-      throw("exception");
+    default: function() {
+      throw "exception";
     }
   }
 ];
@@ -130,14 +130,16 @@ const questionInputDefaultException = [
 const questionsWhen = [
   {
     name: "first",
-    type: "input",
+    type: "input"
   },
   {
     type: "input",
-    when: function() {return false},
+    when: function() {
+      return false;
+    },
     name: "second",
-    validate: async function () {
-        return "Must enter value"
+    validate: async function() {
+      return "Must enter value";
     }
   }
 ];
@@ -150,8 +152,10 @@ const questionInputHint = [
     guiOptions: {
       hint: "hint for input 0"
     },
-    validate: function (input) {
-      return (input.length >= 2) ? true : "Name must be at least 2 characters long";
+    validate: function(input) {
+      return input.length >= 2
+        ? true
+        : "Name must be at least 2 characters long";
     }
   },
   {
@@ -162,16 +166,20 @@ const questionInputHint = [
       hint: "hint for input 1"
     },
     default: "default input",
-    validate: function (input) {
-      return (input.length >= 2) ? true : "Name must be at least 2 characters long";
+    validate: function(input) {
+      return input.length >= 2
+        ? true
+        : "Name must be at least 2 characters long";
     }
   },
   {
     type: "input",
     name: "no_hint_no_deault_validation",
     message: "message for input 2",
-    validate: function (input) {
-      return (input.length >= 2) ? true : "Name must be at least 2 characters long";
+    validate: function(input) {
+      return input.length >= 2
+        ? true
+        : "Name must be at least 2 characters long";
     }
   }
 ];
@@ -185,7 +193,7 @@ const questionInputLink = [
       link: {
         text: "link for input 0",
         url: "https://uri.for.input.0"
-      } 
+      }
     }
   },
   {
@@ -199,7 +207,7 @@ const questionInputLink = [
         command: {
           id: "workbench.action.showCommands"
         }
-      } 
+      }
     }
   },
   {
@@ -209,152 +217,192 @@ const questionInputLink = [
   }
 ];
 
-describe('Questions of type input, password and number', () => {
-  test('Input', async () => {
+/* Validation link test definitions */
+const validationWithLink = {
+  message: "The input is invalid - link",
+  link: {
+    text: "Need help with this error? - link",
+    icon: "data:image/svg+xml;base64, NOT_AN_IMAGE",
+    url: "http://help/with/validation/error"
+  }
+};
+
+const validationWithCommand = {
+  message: "The input is invalid - cmd",
+  link: {
+    text: "Need help with this error? - cmd",
+    command: {
+      id: "a.command.id",
+      params: { prop1: "123", prop2: false }
+    }
+  }
+};
+
+const questionsWithValidateLinks = [
+  {
+    type: "input",
+    name: "validate_with_link",
+    message: "message for input validate_with_link",
+    validate: function(input) {
+      return input ? validationWithLink : true;
+    }
+  },
+  {
+    type: "input",
+    name: "validate_with_command",
+    message: "message for input validate_with_command",
+    validate: function(input) {
+      return input ? validationWithCommand : true;
+    }
+  }
+];
+
+describe("Questions of type input, password and number", () => {
+  test("Input", async () => {
     const value1 = "my input";
 
-    const wrapper = mount(Form, { });
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionInput });
     await Vue.nextTick();
 
-    const name = wrapper.find('input');
+    const name = wrapper.find("input");
     name.element.value = value1;
-    name.trigger('input');
+    name.trigger("input");
 
     // wait to account for debounce
     await utils.sleep(300);
     expect(wrapper.emitted().answered).toBeTruthy();
     const emittedLength = wrapper.emitted().answered.length;
-    const answered = wrapper.emitted().answered[emittedLength-1];
+    const answered = wrapper.emitted().answered[emittedLength - 1];
     // test answers
     expect(answered[0].input).toEqual(value1);
     // test validation
     expect(answered[1]).toBeUndefined();
   });
 
-  test('Input with invalid input', async () => {
+  test("Input with invalid input", async () => {
     const value1 = "m";
 
-    const wrapper = mount(Form, { });
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionInput });
     await Vue.nextTick();
 
-    const name = wrapper.find('input');
+    const name = wrapper.find("input");
     name.element.value = value1;
-    name.trigger('input');
+    name.trigger("input");
 
     // wait to account for debounce
     await utils.sleep(300);
 
     expect(wrapper.emitted().answered).toBeTruthy();
     const emittedLength = wrapper.emitted().answered.length;
-    const answered = wrapper.emitted().answered[emittedLength-1];
+    const answered = wrapper.emitted().answered[emittedLength - 1];
     // test answers
     expect(answered[0].input).toEqual(value1);
     // test validation
     expect(answered[1]).toHaveProperty("input");
   });
 
-  test('Password', async () => {
+  test("Password", async () => {
     const value1 = "my password";
 
-    const wrapper = mount(Form, { });
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionPassword });
     await Vue.nextTick();
 
-    const name = wrapper.find('input');
+    const name = wrapper.find("input");
     name.element.value = value1;
-    name.trigger('input');
+    name.trigger("input");
 
     // wait to account for debounce
     await utils.sleep(300);
 
     expect(wrapper.emitted().answered).toBeTruthy();
     const emittedLength = wrapper.emitted().answered.length;
-    const answered = wrapper.emitted().answered[emittedLength-1];
+    const answered = wrapper.emitted().answered[emittedLength - 1];
     // test answers
     expect(answered[0].password).toEqual(value1);
   });
 
-  test('Number', async () => {
+  test("Number", async () => {
     const value1 = 5;
 
-    const wrapper = mount(Form, { });
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionNumber });
     await Vue.nextTick();
 
-    const name = wrapper.find('input');
+    const name = wrapper.find("input");
     name.element.value = value1;
-    name.trigger('input');
+    name.trigger("input");
 
     // wait to account for debounce
     await utils.sleep(300);
     expect(wrapper.emitted().answered).toBeTruthy();
     const emittedLength = wrapper.emitted().answered.length;
-    const answered = wrapper.emitted().answered[emittedLength-1];
+    const answered = wrapper.emitted().answered[emittedLength - 1];
     // test answers
     expect(answered[0].number).toEqual(value1.toString());
   });
 
-  test('Number without default', async () => {
-    const wrapper = mount(Form, { });
+  test("Number without default", async () => {
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionNumber });
     await Vue.nextTick();
 
-    const name = wrapper.find('input');
+    const name = wrapper.find("input");
     expect(name.element.value).toBe("0");
   });
 
-  test('Input with conditions', async () => {
-    const wrapper = mount(Form, { });
+  test("Input with conditions", async () => {
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionsConditional });
     await Vue.nextTick();
 
     await utils.sleep(300);
     expect(wrapper.emitted().whensEvaluated).toBeTruthy();
 
-    let inputs = wrapper.findAll('input');
+    let inputs = wrapper.findAll("input");
     expect(inputs.length).toEqual(4);
     inputs.at(0).element.value = "hide";
-    inputs.at(0).trigger('input');
+    inputs.at(0).trigger("input");
     // wait to account for debounce
     await utils.sleep(300);
 
-    inputs = wrapper.findAll('input');
+    inputs = wrapper.findAll("input");
     expect(inputs.length).toEqual(3);
   });
 
-  test('Input with message as a function', async () => {
+  test("Input with message as a function", async () => {
     const newValue = "another value";
 
-    const wrapper = mount(Form, { });
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionsMessageAsFunction });
     await Vue.nextTick();
 
-    let inputs = wrapper.findAll('input');
+    let inputs = wrapper.findAll("input");
     inputs.at(0).element.value = newValue;
-    inputs.at(0).trigger('input');
+    inputs.at(0).trigger("input");
     // wait to account for debounce
     await utils.sleep(300);
 
-    inputs = wrapper.findAll('p.question-label > span.question-message');
+    inputs = wrapper.findAll("p.question-label > span.question-message");
     expect(inputs.at(1).element.innerHTML).toBe(`${newValue}-message`);
   });
 
-  test('Input with default as a function', async () => {
+  test("Input with default as a function", async () => {
     const newValue = "another value";
 
-    const wrapper = mount(Form, { });
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionsDefaultAsFunction });
     await Vue.nextTick();
 
-    let inputs = wrapper.findAll('input');
+    let inputs = wrapper.findAll("input");
     inputs.at(0).element.value = newValue;
-    inputs.at(0).trigger('input');
+    inputs.at(0).trigger("input");
     // wait to account for debounce
     await utils.sleep(300);
 
-    inputs = wrapper.findAll('input');
+    inputs = wrapper.findAll("input");
     expect(inputs.at(1).element.value).toBe(`${newValue}-default`);
 
     // Test that default() is not being called when qustion is dirty
@@ -362,36 +410,36 @@ describe('Questions of type input, password and number', () => {
     const anotherValue = "another value";
 
     inputs.at(1).element.value = dirtyValue;
-    inputs.at(1).trigger('input');
+    inputs.at(1).trigger("input");
     // wait to account for debounce
     await utils.sleep(300);
 
-    inputs = wrapper.findAll('input');
+    inputs = wrapper.findAll("input");
     expect(inputs.at(1).element.value).toBe(dirtyValue);
 
     inputs.at(0).element.value = anotherValue;
-    inputs.at(0).trigger('input');
+    inputs.at(0).trigger("input");
     // wait to account for debounce
     await utils.sleep(300);
 
-    inputs = wrapper.findAll('input');
+    inputs = wrapper.findAll("input");
     expect(inputs.at(1).element.value).toBe(dirtyValue);
   });
 
-  test('Input with guiOptions.applyDefaultWhenDirty', async () => {
+  test("Input with guiOptions.applyDefaultWhenDirty", async () => {
     const newValue = "new value";
 
-    const wrapper = mount(Form, { });
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionsWithApplyDefaultWhenDirty });
     await Vue.nextTick();
 
-    let inputs = wrapper.findAll('input');
+    let inputs = wrapper.findAll("input");
     inputs.at(0).element.value = newValue;
-    inputs.at(0).trigger('input');
+    inputs.at(0).trigger("input");
     // wait to account for debounce
     await utils.sleep(300);
 
-    inputs = wrapper.findAll('input');
+    inputs = wrapper.findAll("input");
     expect(inputs.at(1).element.value).toBe(`${newValue}-default`);
 
     // Test that default() is being called when qustion is dirty
@@ -399,42 +447,42 @@ describe('Questions of type input, password and number', () => {
     const anotherValue = "another value";
 
     inputs.at(1).element.value = dirtyValue;
-    inputs.at(1).trigger('input');
+    inputs.at(1).trigger("input");
     // wait to account for debounce
     await utils.sleep(300);
 
-    inputs = wrapper.findAll('input');
+    inputs = wrapper.findAll("input");
     expect(inputs.at(1).element.value).toBe(dirtyValue);
 
     inputs.at(0).element.value = anotherValue;
-    inputs.at(0).trigger('input');
+    inputs.at(0).trigger("input");
     // wait to account for debounce
     await utils.sleep(300);
 
-    inputs = wrapper.findAll('input');
+    inputs = wrapper.findAll("input");
     expect(inputs.at(1).element.value).toBe(`${anotherValue}-default`);
   });
 
-  test('Input with no message', async () => {
-    const wrapper = mount(Form, { });
+  test("Input with no message", async () => {
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionInputNoMessage });
     await Vue.nextTick();
 
-    const inputs = wrapper.findAll('p.question-label > span.question-message');
+    const inputs = wrapper.findAll("p.question-label > span.question-message");
     // message should default to question's name
     expect(inputs.at(0).element.innerHTML).toBe(questionInputNoMessage[0].name);
   });
 
-  test('Input with exception in default()', async () => {
-    const wrapper = mount(Form, { });
+  test("Input with exception in default()", async () => {
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionInputDefaultException });
     await Vue.nextTick();
 
     expect(wrapper.props("questions")[0]._default).toBeUndefined();
   });
 
-  test('when() evaluates to false', async () => {
-    const wrapper = mount(Form, { });
+  test("when() evaluates to false", async () => {
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionsWhen });
     await Vue.nextTick();
     await Vue.nextTick();
@@ -444,55 +492,208 @@ describe('Questions of type input, password and number', () => {
     expect(wrapper.vm.getIssues()).toBe(undefined);
   });
 
-  test('Input with hint', async (done) => {
-    const wrapper = mount(Form, { });
+  test("Input with hint", async done => {
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionInputHint });
     await Vue.nextTick();
     await utils.sleep(300);
 
-    const labels = wrapper.findAll('p.question-label');
+    const labels = wrapper.findAll("p.question-label");
 
-    expect(labels.at(0).findAll('span.question-message').at(0).element.innerHTML).toBe(questionInputHint[0].message);
-    expect(labels.at(0).findAll('span.question-hint').at(0).element.innerHTML).toContain('v-tooltip');
+    expect(
+      labels
+        .at(0)
+        .findAll("span.question-message")
+        .at(0).element.innerHTML
+    ).toBe(questionInputHint[0].message);
+    expect(
+      labels
+        .at(0)
+        .findAll("span.question-hint")
+        .at(0).element.innerHTML
+    ).toContain("v-tooltip");
 
-    expect(labels.at(1).findAll('span.question-message').at(0).element.innerHTML).toBe(questionInputHint[1].message);
-    expect(labels.at(1).findAll('span.question-hint').at(0).element.innerHTML).toContain('v-tooltip');
+    expect(
+      labels
+        .at(1)
+        .findAll("span.question-message")
+        .at(0).element.innerHTML
+    ).toBe(questionInputHint[1].message);
+    expect(
+      labels
+        .at(1)
+        .findAll("span.question-hint")
+        .at(0).element.innerHTML
+    ).toContain("v-tooltip");
 
-    expect(labels.at(2).findAll('span.question-message').at(0).element.innerHTML).toBe(questionInputHint[2].message);
-    expect(labels.at(2).findAll('span.question-hint').exists()).toBe(false);
+    expect(
+      labels
+        .at(2)
+        .findAll("span.question-message")
+        .at(0).element.innerHTML
+    ).toBe(questionInputHint[2].message);
+    expect(
+      labels
+        .at(2)
+        .findAll("span.question-hint")
+        .exists()
+    ).toBe(false);
 
-    labels.at(0).find({name: 'v-icon'}).trigger('mouseenter');
+    labels
+      .at(0)
+      .find({ name: "v-icon" })
+      .trigger("mouseenter");
     await Vue.nextTick();
-    requestAnimationFrame(() => { // https://github.com/vuejs/vue-test-utils/issues/1421
+    requestAnimationFrame(() => {
+      // https://github.com/vuejs/vue-test-utils/issues/1421
       expect(wrapper.text()).toContain(questionInputHint[0].guiOptions.hint);
       done();
-    })
-
+    });
   });
 
-  test('Input with link', async () => {
-    const wrapper = mount(Form, { });
+  test("Input with link", async () => {
+    const wrapper = mount(Form, {});
     wrapper.setProps({ questions: questionInputLink });
     await Vue.nextTick();
     await utils.sleep(300);
 
-    const labels = wrapper.findAll('p.question-label');
+    const labels = wrapper.findAll("p.question-label");
 
-    expect(labels.at(0).findAll('span.question-message').at(0).element.innerHTML).toBe(questionInputLink[0].message);
-    expect(labels.at(0).findAll('span.question-link').at(0).element.innerHTML).toContain('a');
-    expect(labels.at(0).findAll('span.question-link').at(0).element.innerHTML).toContain('href');
-    expect(labels.at(0).findAll('a').at(0).element.innerHTML).toBe(questionInputLink[0].guiOptions.link.text);
-    expect(labels.at(0).findAll('a').at(0).element.href).toContain(questionInputLink[0].guiOptions.link.url);
+    expect(
+      labels
+        .at(0)
+        .findAll("span.question-message")
+        .at(0).element.innerHTML
+    ).toBe(questionInputLink[0].message);
+    expect(
+      labels
+        .at(0)
+        .findAll("span.question-link")
+        .at(0).element.innerHTML
+    ).toContain("a");
+    expect(
+      labels
+        .at(0)
+        .findAll("span.question-link")
+        .at(0).element.innerHTML
+    ).toContain("href");
+    expect(
+      labels
+        .at(0)
+        .findAll("a")
+        .at(0).element.innerHTML
+    ).toBe(questionInputLink[0].guiOptions.link.text);
+    expect(
+      labels
+        .at(0)
+        .findAll("a")
+        .at(0).element.href
+    ).toContain(questionInputLink[0].guiOptions.link.url);
 
-    expect(labels.at(1).findAll('span.question-message').at(0).element.innerHTML).toBe(questionInputLink[1].message);
-    expect(labels.at(1).findAll('span.question-link').at(0).element.innerHTML).toContain('a');
-    expect(labels.at(1).findAll('span.question-link').at(0).element.innerHTML).toContain('command');
-    expect(labels.at(1).findAll('a').at(0).element.innerHTML).toBe(questionInputLink[1].guiOptions.link.text);
-    expect(labels.at(1).findAll('a').at(0).element.attributes.command.value).toBe(questionInputLink[1].guiOptions.link.command.id);
+    expect(
+      labels
+        .at(1)
+        .findAll("span.question-message")
+        .at(0).element.innerHTML
+    ).toBe(questionInputLink[1].message);
+    expect(
+      labels
+        .at(1)
+        .findAll("span.question-link")
+        .at(0).element.innerHTML
+    ).toContain("a");
+    expect(
+      labels
+        .at(1)
+        .findAll("span.question-link")
+        .at(0).element.innerHTML
+    ).toContain("command");
+    expect(
+      labels
+        .at(1)
+        .findAll("a")
+        .at(0).element.innerHTML
+    ).toBe(questionInputLink[1].guiOptions.link.text);
+    expect(
+      labels
+        .at(1)
+        .findAll("a")
+        .at(0).element.attributes.command.value
+    ).toBe(questionInputLink[1].guiOptions.link.command.id);
 
-    expect(labels.at(2).findAll('span.question-message').at(0).element.innerHTML).toBe(questionInputLink[2].message);
-    expect(labels.at(2).findAll('span.question-link').exists()).toBe(false);
-
+    expect(
+      labels
+        .at(2)
+        .findAll("span.question-message")
+        .at(0).element.innerHTML
+    ).toBe(questionInputLink[2].message);
+    expect(
+      labels
+        .at(2)
+        .findAll("span.question-link")
+        .exists()
+    ).toBe(false);
   });
 
+  test("Input with validationLink", async () => {
+    const wrapper = mount(Form, {});
+    wrapper.setProps({ questions: questionsWithValidateLinks });
+    await Vue.nextTick();
+    await utils.sleep(300);
+
+    const allInputs = wrapper.findAll("input");
+
+    expect(wrapper.find("#validation-msg-" + 0).exists()).toBe(false);
+    expect(wrapper.find("#validation-msg-" + 1).exists()).toBe(false);
+
+    // Question at index 0 is validation with url link
+    const valWithLinkInput = allInputs.at(0);
+    valWithLinkInput.element.value = "anyvalue0";
+    valWithLinkInput.trigger("input");
+    // wait to account for debounce
+    await utils.sleep(300);
+
+    // Check validation messages
+    const validationMsgWithLink = wrapper.find("#validation-msg-" + 0);
+
+    expect(
+      validationMsgWithLink.find("span.error-validation-text").element.innerHTML
+    ).toEqual(validationWithLink.message);
+
+    expect(validationMsgWithLink.find("span.question-link").exists()).toBe(
+      true
+    );
+
+    expect(
+      validationMsgWithLink
+        .find("img.validation-link-icon")
+        .element.getAttribute("src")
+    ).toEqual(validationWithLink.link.icon);
+
+    expect(
+      validationMsgWithLink.find("a").element.getAttribute("href")
+    ).toEqual(validationWithLink.link.url);
+    expect(validationMsgWithLink.find("#urlLinkText").text()).toEqual(
+      validationWithLink.link.text
+    );
+
+    // Question at index 1 is validation with command link
+    const valWithCmdInput = allInputs.at(1);
+    valWithCmdInput.element.value = "anyvalue1";
+    valWithCmdInput.trigger("input");
+    // wait to account for debounce
+    await utils.sleep(300);
+
+    const validationMsgWithCmd = wrapper.find("#validation-msg-" + 1);
+    expect(
+      validationMsgWithCmd.find("span.error-validation-text").element.innerHTML
+    ).toEqual(validationWithCommand.message);
+
+    expect(validationMsgWithCmd.find("span.question-link").exists()).toBe(true);
+
+    expect(validationMsgWithCmd.find("img.validation-link-icon").exists()).toBe(
+      false
+    );
+    expect(validationMsgWithCmd.find("#cmdLinkText").text()).toEqual(validationWithCommand.link.text);
+  }, 1000000);
 });

--- a/__tests__/list.spec.js
+++ b/__tests__/list.spec.js
@@ -164,7 +164,7 @@ describe('Question of type list', () => {
     expect(answered[0].country).toBeUndefined();
 
     // test validation text
-    const errors = wrapper.findAll('div.error-validation-text');
+    const errors = wrapper.findAll('span.error-validation-text');
     expect(errors.at(0).element.innerHTML).toBe('Mandatory field');
 
   });
@@ -303,7 +303,7 @@ describe('Question of type list', () => {
     await Vue.nextTick();
 
     // should get 2 * and validation error message from list2
-    let errorValidationText = wrapper.findAll("div.error-validation-text");
+    let errorValidationText = wrapper.findAll("span.error-validation-text");
     expect(errorValidationText.length).toEqual(1);
     let mandatoryAsterisk = wrapper.findAll("span.mandatory-asterisk");
     expect(mandatoryAsterisk.length).toEqual(2);
@@ -314,7 +314,7 @@ describe('Question of type list', () => {
     await Vue.nextTick();
 
     // should get 3 * and validation error message from list3
-    errorValidationText = wrapper.findAll("div.error-validation-text");
+    errorValidationText = wrapper.findAll("span.error-validation-text");
     expect(errorValidationText.length).toEqual(1);
     mandatoryAsterisk = wrapper.findAll("span.mandatory-asterisk");
     expect(mandatoryAsterisk.length).toEqual(3);
@@ -325,7 +325,7 @@ describe('Question of type list', () => {
     await Vue.nextTick();
 
     // should get 3 * and no validation error messages
-    errorValidationText = wrapper.findAll("div.error-validation-text");
+    errorValidationText = wrapper.findAll("span.error-validation-text");
     expect(errorValidationText.length).toEqual(0);
     mandatoryAsterisk = wrapper.findAll("span.mandatory-asterisk");
     expect(mandatoryAsterisk.length).toEqual(3);


### PR DESCRIPTION
… be used by YeomanU

Adds support for validation messages to be shown in YeomanUI that can link to contextual help by executing a command or a direct url link.

A new type definition for the validation link object and an updated command handler will be added to YeomanUI. The type defintion will require a `toString` function to be provided so a nicely formatted output can still be provided on the Yo cli.