### PR TITLE
fix(tiles plugin): overflow in compact mode

### DIFF
--- a/tiles-plugin/package.json
+++ b/tiles-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sap-devx/inquirer-gui-tiles-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Tiles plugin for inquirer-gui",
   "main": "dist/tilesPlugin.umd.js",
   "scripts": {

--- a/tiles-plugin/src/packages/QuestionTiles.vue
+++ b/tiles-plugin/src/packages/QuestionTiles.vue
@@ -101,8 +101,7 @@ export default {
   -webkit-box-orient: vertical;
   display: -webkit-box;
   padding-bottom: 0px;
-  padding-top: 0px;
-  min-height: calc(1.375rem * 3) 
+  padding-top: 0px; 
 }
 .homepage.v-card__text {
   padding-bottom: 0;


### PR DESCRIPTION
Fix for compact `tiles-plugin` when using compact mode. Long text can cause overflow when re-sizing :

<img width="762" alt="image" src="https://github.com/SAP/inquirer-gui/assets/46536134/7abe25b0-fc96-440a-8fdf-7c776aadb16a">

Fixed:

<img width="924" alt="image" src="https://github.com/SAP/inquirer-gui/assets/46536134/42f4eb2e-3ad5-455d-aa5a-b1495b5bd652">

This fix aligns the behaviour between normal and compact size tiles. It can probably be improved once we have Vue 3 perhaps using fixed width columns.
