### PR TITLE
feat: extended QuestionConfirm label customization

### DIFF
--- a/examples/sample-app-vite/src/main.js
+++ b/examples/sample-app-vite/src/main.js
@@ -417,6 +417,8 @@ const questions2 = [
     type: "confirm",
     name: "confirm",
     message: "Are you sure?",
+    labelTrue: "Yes, I am sure!",
+    labelFalse: "No, I am still contemplating...",
     default: false,
   },
   {

--- a/examples/sample-app/src/main.js
+++ b/examples/sample-app/src/main.js
@@ -415,6 +415,8 @@ const questions2 = [
     type: "confirm",
     name: "confirm",
     message: "Are you sure?",
+    labelTrue: "Yes, I am sure!",
+    labelFalse: "No, I am still contemplating...",
     default: false,
   },
   {

--- a/examples/sample-app/src/main.js
+++ b/examples/sample-app/src/main.js
@@ -360,6 +360,13 @@ const questions1 = [
     choices: ["Yes", "No", "Maybe"],
     default: "No",
   },
+  {
+    type: "confirm",
+    name: "confirm",
+    message: "Do you want to save your changes?",
+    labelFalse: "No, discard changes",
+    default: false,
+  },
 ];
 
 const questions2 = [

--- a/packages/inquirer-gui/__tests__/confirm.spec.js
+++ b/packages/inquirer-gui/__tests__/confirm.spec.js
@@ -11,11 +11,31 @@ const questionConfirm = [
     type: "confirm",
     name: "confirm",
     message: "Are you sure?",
+    default: false,
+  },
+];
+
+const questionConfirmWithOneLabel = [
+  {
+    type: "confirm",
+    name: "confirm",
+    message: "Do you agree?",
+    labelTrue: "Accept",
+    default: false,
+  },
+];
+
+const questionConfirmWithTwoLabels = [
+  {
+    type: "confirm",
+    name: "confirm",
+    message: "Do you agree?",
     labelTrue: "Accept",
     labelFalse: "Decline",
     default: false,
   },
 ];
+
 enableAutoUnmount(afterEach); //Ensures wrapper component gets cleaned up after each test
 describe("Question of type confirm", () => {
   let vuetify;
@@ -42,6 +62,90 @@ describe("Question of type confirm", () => {
 
     const confirm = wrapper.find("label");
     confirm.trigger("click");
+
+    await nextTick();
+    expect(wrapper.emitted().answered).toBeTruthy();
+    const emittedLength = wrapper.emitted().answered.length;
+    const answered = wrapper.emitted().answered[emittedLength - 1];
+    // test answers
+    expect(answered[0].confirm).toEqual(true);
+  });
+
+  test("Confirm renders default labels", async () => {
+    const wrapper = mount(FormVue, {
+      global: {
+        plugins: [vuetify],
+        components: {
+          QuestionConfirm: QuestionConfirm,
+        },
+      },
+      attachTo: document.body,
+    });
+    wrapper.setProps({ questions: questionConfirm });
+    await nextTick();
+
+    const labels = wrapper.findAll("label");
+
+    expect(labels.at(0).text()).toBe("Yes");
+    expect(labels.at(1).text()).toBe("No");
+
+    labels.at(0).trigger("click");
+
+    await nextTick();
+    expect(wrapper.emitted().answered).toBeTruthy();
+    const emittedLength = wrapper.emitted().answered.length;
+    const answered = wrapper.emitted().answered[emittedLength - 1];
+    // test answers
+    expect(answered[0].confirm).toEqual(true);
+  });
+
+  test("Confirm renders only one overridden label", async () => {
+    const wrapper = mount(FormVue, {
+      global: {
+        plugins: [vuetify],
+        components: {
+          QuestionConfirm: QuestionConfirm,
+        },
+      },
+      attachTo: document.body,
+    });
+    wrapper.setProps({ questions: questionConfirmWithOneLabel });
+    await nextTick();
+
+    const labels = wrapper.findAll("label");
+
+    expect(labels.at(0).text()).toBe("Accept");
+    expect(labels.at(1).text()).toBe("No");
+
+    labels.at(0).trigger("click");
+
+    await nextTick();
+    expect(wrapper.emitted().answered).toBeTruthy();
+    const emittedLength = wrapper.emitted().answered.length;
+    const answered = wrapper.emitted().answered[emittedLength - 1];
+    // test answers
+    expect(answered[0].confirm).toEqual(true);
+  });
+
+  test("Confirm renders two overridden labels", async () => {
+    const wrapper = mount(FormVue, {
+      global: {
+        plugins: [vuetify],
+        components: {
+          QuestionConfirm: QuestionConfirm,
+        },
+      },
+      attachTo: document.body,
+    });
+    wrapper.setProps({ questions: questionConfirmWithTwoLabels });
+    await nextTick();
+
+    const labels = wrapper.findAll("label");
+
+    expect(labels.at(0).text()).toBe("Accept");
+    expect(labels.at(1).text()).toBe("Decline");
+
+    labels.at(0).trigger("click");
 
     await nextTick();
     expect(wrapper.emitted().answered).toBeTruthy();

--- a/packages/inquirer-gui/__tests__/confirm.spec.js
+++ b/packages/inquirer-gui/__tests__/confirm.spec.js
@@ -11,8 +11,6 @@ const questionConfirm = [
     type: "confirm",
     name: "confirm",
     message: "Are you sure?",
-    labelTrue: "Accept",
-    labelFalse: "Decline",
     default: false,
   },
 ];

--- a/packages/inquirer-gui/__tests__/confirm.spec.js
+++ b/packages/inquirer-gui/__tests__/confirm.spec.js
@@ -11,6 +11,8 @@ const questionConfirm = [
     type: "confirm",
     name: "confirm",
     message: "Are you sure?",
+    labelTrue: "Accept",
+    labelFalse: "Decline",
     default: false,
   },
 ];

--- a/packages/inquirer-gui/src/packages/QuestionConfirm.vue
+++ b/packages/inquirer-gui/src/packages/QuestionConfirm.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <v-radio-group @update:modelValue="onClick" :modelValue="question.answer" inline density="compact">
-      <v-radio label="Yes" :value="true"></v-radio>
-      <v-radio label="No" :value="false"></v-radio>
+      <v-radio :label="question.labelTrue || 'Yes'" :value="true"></v-radio>
+      <v-radio :label="question.labelFalse || 'No'" :value="false"></v-radio>
     </v-radio-group>
   </div>
 </template>


### PR DESCRIPTION
Added the ability to customize the accept and reject labels of the QuestionConfirm component, instead of simply keeping them as "Yes" and "No". These two options are now set to default and can be overridden using the `labelTrue` and `labelFalse` properties when creating a new input object.

```
const example =  {
    type: "confirm",
    name: "confirm",
    message: "Do you accept the Terms & Conditions?",
    labelTrue: "Accept",
    labelFalse: "Reject",
    default: false,
  }
```