### PR TITLE
fix(ci): use npm ci to prevent package-lock.json modifications on Linux

### DIFF
--- a/.github/workflows/bump-versions-and-tag.yml
+++ b/.github/workflows/bump-versions-and-tag.yml
@@ -34,7 +34,9 @@ jobs:
           node-version: "24.x"
 
       - name: Install dependencies
-        run: npm install
+        # Use npm ci instead of npm install to avoid modifying package-lock.json on Linux
+        # (platform-specific optional deps from vite/rollup would dirty the working tree and cause lerna to abort)
+        run: npm ci
 
       - name: Ensure Build Is Green
         run: npm run ci


### PR DESCRIPTION
## Summary
- Replace `npm install` with `npm ci` in the `bump-versions-and-tag` workflow
- `npm install` on Linux (ubuntu-latest) adds platform-specific optional dependencies from `vite`/`rollup`, modifying `package-lock.json` and causing lerna to abort with `EUNCOMMIT`
- `npm ci` installs strictly from the lockfile without modifying it

## Test plan
- [ ] Trigger the `Bump Versions and Tag` workflow and verify it completes without the `EUNCOMMIT` error