### PR TITLE
fix(ci): use npm install --omit=optional to prevent lockfile changes on Linux

### DIFF
--- a/.github/workflows/bump-versions-and-tag.yml
+++ b/.github/workflows/bump-versions-and-tag.yml
@@ -34,9 +34,9 @@ jobs:
           node-version: "24.x"
 
       - name: Install dependencies
-        # Use npm ci instead of npm install to avoid modifying package-lock.json on Linux
-        # (platform-specific optional deps from vite/rollup would dirty the working tree and cause lerna to abort)
-        run: npm ci
+        # --omit=optional skips platform-specific native binaries (e.g. rollup, encoding)
+        # so npm install does not modify package-lock.json on Linux and lerna sees a clean tree
+        run: npm install --omit=optional
 
       - name: Ensure Build Is Green
         run: npm run ci

--- a/.github/workflows/bump-versions-and-tag.yml
+++ b/.github/workflows/bump-versions-and-tag.yml
@@ -34,7 +34,9 @@ jobs:
           node-version: "24.x"
 
       - name: Install dependencies
-        run: npm install
+        # Use npm ci instead of npm install to avoid modifying package-lock.json on Linux
+        # (platform-specific optional deps from vite/rollup would dirty the working tree and cause lerna to abort)
+        run: npm ci
 
       - name: Ensure Build Is Green
         run: npm run ci


### PR DESCRIPTION
## Summary
- Replaces `npm ci` (which failed due to `encoding@0.1.13` missing from the macOS-generated lockfile) with `npm install --omit=optional`
- Platform-specific optional deps (rollup binaries, `encoding`) are resolved differently per OS, causing `npm install` to dirty `package-lock.json` on Linux and making lerna abort with `EUNCOMMIT`
- `--omit=optional` skips those deps entirely — safe here as Vite/Rollup fall back to their JS implementations automatically, and this workflow only needs to build, test, and tag

## Test plan
- [ ] Trigger the `Bump Versions and Tag` workflow and verify it completes without the `EUNCOMMIT` error