### PR TITLE
fix: compare expand object defaults deeply

### DIFF
--- a/packages/inquirer-gui/__tests__/expand.spec.js
+++ b/packages/inquirer-gui/__tests__/expand.spec.js
@@ -26,6 +26,19 @@ const questionExpandDefaultValue = [
   },
 ];
 
+const questionExpandObjectDefaultValue = [
+  {
+    type: "expand",
+    name: "country",
+    message: "Choose a country",
+    choices: [
+      { name: "United States of America", value: { country: "USA", currency: "Dollar" } },
+      { name: "People's Republic of China", value: { country: "China", currency: "Yen" } },
+    ],
+    default: { country: "China", currency: "Yen" },
+  },
+];
+
 const questionExpandNoDefault = [
   {
     type: "expand",
@@ -114,6 +127,23 @@ describe("Question of type expand", () => {
 
     // test answers
     expect(wrapper.props("questions")[0].answer).toEqual("No");
+  });
+
+  test("Expand with object default value", async () => {
+    const wrapper = mount(FormVue, {
+      global: {
+        plugins: [vuetify],
+        components: {
+          QuestionExpand: QuestionExpand,
+        },
+        stubs: vscodeStubs,
+      },
+      attachTo: document.body,
+    });
+    wrapper.setProps({ questions: questionExpandObjectDefaultValue });
+    await nextTick();
+
+    expect(wrapper.props("questions")[0].answer).toStrictEqual({ country: "China", currency: "Yen" });
   });
 
   test("Expand without default", async () => {

--- a/packages/inquirer-gui/src/Form.vue
+++ b/packages/inquirer-gui/src/Form.vue
@@ -407,7 +407,7 @@ export default {
           } else {
             index = question._choices.findIndex(function (choice) {
               if (question._default) {
-                return choice.value === question._default;
+                return isEqual(choice.value, question._default);
               }
             });
           }


### PR DESCRIPTION
## Summary
- use deep equality for expand prompt object defaults
- add a regression test for object default values

Refs #787

## Checks
- npm test -- --coverage=false
- npm run build
- prettier --check packages/inquirer-gui/src/Form.vue packages/inquirer-gui/__tests__/expand.spec.js
- eslint packages/inquirer-gui/src/Form.vue packages/inquirer-gui/__tests__/expand.spec.js
- git diff --check
