### PR TITLE
fix(inquirer-gui): fix capitalisation of output tab link message 

### DIFF
--- a/packages/inquirer-gui/__tests__/output-tab-link.spec.js
+++ b/packages/inquirer-gui/__tests__/output-tab-link.spec.js
@@ -80,7 +80,7 @@ enableAutoUnmount(afterEach);
 describe("OutputTabLink component", () => {
   test("renders default link message when no linkMessage prop provided", () => {
     const wrapper = mount(OutputTabLink);
-    expect(wrapper.find("a").text()).toBe("View details in the output tab.");
+    expect(wrapper.find("a").text()).toBe("View Details in the Output Tab.");
   });
 
   test("renders custom linkMessage when prop is provided", () => {

--- a/packages/inquirer-gui/src/packages/OutputTabLink.vue
+++ b/packages/inquirer-gui/src/packages/OutputTabLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="output-tab-link">
-    <a @click="$emit('show-output-tab-link')">{{ linkMessage || "View details in the output tab." }}</a>
+    <a @click="$emit('show-output-tab-link')">{{ linkMessage || "View Details in the Output Tab." }}</a>
   </div>
 </template>
 


### PR DESCRIPTION
## Description

Fixes the capitalisation of the default link message in the `OutputTabLink` component.

Fixes internal issue #38362

## Changes

- `OutputTabLink.vue`: Changed default `linkMessage` from `"View details in the output tab."` to `"View Details in the Output Tab."`
- `output-tab-link.spec.js`: Updated test expectation to match the corrected text

## Steps to Reproduce (from issue)

1. Go to Application Wizard and start generating an app
2. In the Data Source and Service Selection step, find a service that throws an error
3. Make the VSCode window narrow enough to see the output tab link

## Before / After

| Before | After |
|--------|-------|
| "View details in the output tab." | "View Details in the Output Tab." |