### PR TITLE
Revert change that introduced bug - only show validation or additional messages

### DIFF
--- a/packages/inquirer-gui/src/Form.vue
+++ b/packages/inquirer-gui/src/Form.vue
@@ -62,7 +62,7 @@
         </span>
       </div>
       <div
-        v-if="shouldShowAdditionalMessages(question)"
+        v-else-if="shouldShowAdditionalMessages(question)"
         class="add-messages"
         :key="'additional-msg-' + index"
         :id="'add-msg-' + index"


### PR DESCRIPTION
Reverts change that resulted in `additionalMessages` being shown incorrectly.

https://github.com/SAP/inquirer-gui/pull/804/changes#diff-73cbb627530a269739a1e6334dd5de416c85419d5fee4bfbdd6a8e8b42e844c4L63

Bug, both message types should not be shown together e.g. `URL not found` and `Authentication failed...` :

<img width="601" height="286" alt="image" src="https://github.com/user-attachments/assets/f15df30c-befb-46c4-8968-98b0ad2d65bd" />


