### PR TITLE
fix(inquirer-gui): only allow additional or validation messages to be displayed

### DIFF
--- a/packages/inquirer-gui/__tests__/input.spec.js
+++ b/packages/inquirer-gui/__tests__/input.spec.js
@@ -292,6 +292,17 @@ const questionsWithValidateLinks = [
   },
 ];
 
+const questionAddMsgAndValidation = [
+  {
+    type: "input",
+    name: "addmsg_then_validation",
+    message: "message for addmsg_then_validation",
+    validate: (input) => (input === "triggerVal" ? "Some validation message" : true),
+    additionalMessages: (input) =>
+      input === "triggerWarn" ? { message: "Some warning message", severity: 1 } : undefined,
+  },
+];
+
 const questionsWithAdditionalMessages = [
   {
     type: "input",
@@ -920,6 +931,40 @@ describe("Questions of type input, password and number", () => {
     ).toEqual("text validation message 1234");
     expect(validationMsgWithCmd.find("span.question-link").isVisible()).toBe(false);
     expect(validationMsgWithCmd.find("#cmdLinkText").exists()).toBe(false); */
+  });
+
+  test("Input validation message replaces previously shown additional message", async () => {
+    const wrapper = mount(FormVue, {
+      global: {
+        plugins: [vuetify],
+        stubs: vscodeStubs,
+        components: { QuestionInput: InputVue },
+      },
+      attachTo: document.body,
+    });
+    wrapper.setProps({ questions: questionAddMsgAndValidation });
+    await nextTick();
+    await utils.sleep(300);
+
+    const input = wrapper.findAll("input").at(0);
+
+    // Given: input value that triggers an additional (warning) message
+    input.setValue("triggerWarn");
+    await utils.sleep(300);
+
+    expect(wrapper.find(".add-messages").exists()).toBe(true);
+    expect(wrapper.find(".add-messages span.messages-text").text()).toEqual("Some warning message");
+    expect(wrapper.find("#validation-msg-0").exists()).toBe(false);
+
+    // When: input value changes to one that fails validation
+    input.setValue("triggerVal");
+    await utils.sleep(300);
+
+    // Then: validation message is shown AND the additional message is gone
+    const validationMsg = wrapper.find("#validation-msg-0");
+    expect(validationMsg.exists()).toBe(true);
+    expect(validationMsg.find("span.error-validation-text").element.innerHTML).toEqual("Some validation message");
+    expect(wrapper.find(".add-messages").exists()).toBe(false);
   });
 
   test("Input with additional messages", async () => {

--- a/packages/inquirer-gui/src/Form.vue
+++ b/packages/inquirer-gui/src/Form.vue
@@ -62,7 +62,7 @@
         </span>
       </div>
       <div
-        v-if="shouldShowAdditionalMessages(question)"
+        v-else-if="shouldShowAdditionalMessages(question)"
         class="add-messages"
         :key="'additional-msg-' + index"
         :id="'add-msg-' + index"


### PR DESCRIPTION
Reverts change that resulted in `additionalMessages` being shown incorrectly.

https://github.com/SAP/inquirer-gui/pull/804/changes#diff-73cbb627530a269739a1e6334dd5de416c85419d5fee4bfbdd6a8e8b42e844c4L63

Bug, both message types should not be shown together e.g. `URL not found` and `Authentication failed...` :

<img width="601" height="286" alt="image" src="https://github.com/user-attachments/assets/f15df30c-befb-46c4-8968-98b0ad2d65bd" />


