### PR TITLE
fix(inquirer-gui): text clipping in vscode-textfield

### DIFF
--- a/packages/file-browser-plugin/__tests__/file.browser.spec.js
+++ b/packages/file-browser-plugin/__tests__/file.browser.spec.js
@@ -4,6 +4,7 @@ import { nextTick } from "vue";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/lib/components/index.mjs";
 import FormVue from "../../inquirer-gui/src/Form.vue";
+import QuestionFileBrowser from "../src/packages/QuestionFileBrowser.vue";
 
 import QuestionFileBrowserPlugin from "../../file-browser-plugin/src";
 // import QuestionFileBrowserPlugin from "@sap-devx/inquirer-gui-file-browser-plugin";
@@ -100,5 +101,56 @@ describe("Question of type file browser", () => {
     const emittedPayload = emittedEvent[emittedEvent.length - 1];
     expect(emittedPayload[0].configFile).toEqual("/home/user");
     expect(emittedPayload[1]).toBeUndefined();
+  });
+});
+
+describe("mountLineHeightPatch in QuestionFileBrowser", () => {
+  test("injects exactly one style.line-height-patch and is idempotent", () => {
+    const styleNodes = [];
+    const mockShadowRoot = {
+      querySelector: () => styleNodes.find((n) => n.className === "line-height-patch") || null,
+      appendChild: (node) => styleNodes.push(node),
+    };
+    const wrapper = mount(QuestionFileBrowser, {
+      props: { question: { name: "test", answer: "", type: "input" } },
+      global: {
+        stubs: {
+          "vscode-textfield": { template: "<div><slot></slot></div>" },
+          "v-tooltip": { template: "<div><slot name='activator' :props='{}'></slot></div>" },
+          "v-icon": { template: "<i></i>" },
+        },
+      },
+    });
+    Object.defineProperty(wrapper.vm.$refs.textfield, "shadowRoot", { value: mockShadowRoot, writable: true });
+    Object.defineProperty(wrapper.vm.$refs.textfield, "updateComplete", { value: undefined, writable: true });
+    wrapper.vm.$options.mounted.call(wrapper.vm);
+    wrapper.vm.$options.mounted.call(wrapper.vm);
+    expect(styleNodes.length).toBe(1);
+    expect(styleNodes[0].className).toBe("line-height-patch");
+    expect(styleNodes[0].textContent).toContain("line-height: normal");
+  });
+
+  test("injects patch after updateComplete resolves", async () => {
+    const styleNodes = [];
+    const mockShadowRoot = {
+      querySelector: () => styleNodes.find((n) => n.className === "line-height-patch") || null,
+      appendChild: (node) => styleNodes.push(node),
+    };
+    const wrapper = mount(QuestionFileBrowser, {
+      props: { question: { name: "test", answer: "", type: "input" } },
+      global: {
+        stubs: {
+          "vscode-textfield": { template: "<div><slot></slot></div>" },
+          "v-tooltip": { template: "<div><slot name='activator' :props='{}'></slot></div>" },
+          "v-icon": { template: "<i></i>" },
+        },
+      },
+    });
+    Object.defineProperty(wrapper.vm.$refs.textfield, "shadowRoot", { value: mockShadowRoot, writable: true });
+    Object.defineProperty(wrapper.vm.$refs.textfield, "updateComplete", { value: Promise.resolve(), writable: true });
+    wrapper.vm.$options.mounted.call(wrapper.vm);
+    await Promise.resolve();
+    expect(styleNodes.length).toBe(1);
+    expect(styleNodes[0].className).toBe("line-height-patch");
   });
 });

--- a/packages/file-browser-plugin/src/packages/QuestionFileBrowser.vue
+++ b/packages/file-browser-plugin/src/packages/QuestionFileBrowser.vue
@@ -12,10 +12,15 @@
 </template>
 
 <script>
+import { mountLineHeightPatch } from "../../../inquirer-gui/src/utils";
+
 export default {
   name: "QuestionFileBrowser",
   props: {
     question: Object,
+  },
+  mounted() {
+    mountLineHeightPatch(this.$refs.path);
   },
   data: () => ({
     path: "/home/",

--- a/packages/file-browser-plugin/src/packages/QuestionFileBrowser.vue
+++ b/packages/file-browser-plugin/src/packages/QuestionFileBrowser.vue
@@ -1,5 +1,5 @@
 <template>
-  <vscode-textfield ref="path" @change="onAnswerChanged" :value="question.answer">
+  <vscode-textfield ref="textfield" @change="onAnswerChanged" :value="question.answer">
     <template slot="content-after">
       <v-tooltip location="top">
         <template v-slot:activator="{ props }">
@@ -12,7 +12,26 @@
 </template>
 
 <script>
-import { mountLineHeightPatch } from "../../../inquirer-gui/src/utils";
+// @vscode-elements/elements@1.11.0 hardcodes line-height: 18px on the inner
+// <input> with no CSS custom property hook. Remove this patch when the library
+// exposes one (e.g. --vscode-input-line-height).
+function applyPatch(el) {
+  if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
+    const style = document.createElement("style");
+    style.className = "line-height-patch";
+    // !important needed to override the library's hardcoded constructed stylesheet
+    style.textContent = "input { line-height: normal !important; }";
+    el.shadowRoot.appendChild(style);
+  }
+}
+
+function mountLineHeightPatch(el) {
+  if (el && typeof el.updateComplete !== "undefined") {
+    el.updateComplete.then(() => applyPatch(el));
+  } else {
+    applyPatch(el); // fallback for non-Lit environments; usually a no-op in tests
+  }
+}
 
 export default {
   name: "QuestionFileBrowser",
@@ -20,7 +39,7 @@ export default {
     question: Object,
   },
   mounted() {
-    mountLineHeightPatch(this.$refs.path);
+    mountLineHeightPatch(this.$refs.textfield);
   },
   data: () => ({
     path: "/home/",

--- a/packages/folder-browser-plugin/src/packages/QuestionFolderBrowser.vue
+++ b/packages/folder-browser-plugin/src/packages/QuestionFolderBrowser.vue
@@ -12,10 +12,15 @@
 </template>
 
 <script>
+import { mountLineHeightPatch } from "../../../inquirer-gui/src/utils";
+
 export default {
   name: "QuestionFolderBrowser",
   props: {
     question: Object,
+  },
+  mounted() {
+    mountLineHeightPatch(this.$refs.path);
   },
   data: () => ({
     path: "/home/",

--- a/packages/folder-browser-plugin/src/packages/QuestionFolderBrowser.vue
+++ b/packages/folder-browser-plugin/src/packages/QuestionFolderBrowser.vue
@@ -1,5 +1,5 @@
 <template>
-  <vscode-textfield ref="path" @change="onAnswerChanged" :value="question.answer">
+  <vscode-textfield ref="textfield" @change="onAnswerChanged" :value="question.answer">
     <template slot="content-after">
       <v-tooltip location="top">
         <template v-slot:activator="{ props }">
@@ -12,7 +12,26 @@
 </template>
 
 <script>
-import { mountLineHeightPatch } from "../../../inquirer-gui/src/utils";
+// @vscode-elements/elements@1.11.0 hardcodes line-height: 18px on the inner
+// <input> with no CSS custom property hook. Remove this patch when the library
+// exposes one (e.g. --vscode-input-line-height).
+function applyPatch(el) {
+  if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
+    const style = document.createElement("style");
+    style.className = "line-height-patch";
+    // !important needed to override the library's hardcoded constructed stylesheet
+    style.textContent = "input { line-height: normal !important; }";
+    el.shadowRoot.appendChild(style);
+  }
+}
+
+function mountLineHeightPatch(el) {
+  if (el && typeof el.updateComplete !== "undefined") {
+    el.updateComplete.then(() => applyPatch(el));
+  } else {
+    applyPatch(el); // fallback for non-Lit environments; usually a no-op in tests
+  }
+}
 
 export default {
   name: "QuestionFolderBrowser",
@@ -20,7 +39,7 @@ export default {
     question: Object,
   },
   mounted() {
-    mountLineHeightPatch(this.$refs.path);
+    mountLineHeightPatch(this.$refs.textfield);
   },
   data: () => ({
     path: "/home/",

--- a/packages/inquirer-gui/__tests__/input.spec.js
+++ b/packages/inquirer-gui/__tests__/input.spec.js
@@ -1512,12 +1512,30 @@ describe("mountLineHeightPatch shadow DOM injection", () => {
       props: { question: { name: "test", answer: "", type: "input" } },
       global: { stubs: vscodeStubs },
     });
-    Object.defineProperty(wrapper.vm.$el, "shadowRoot", { value: mockShadowRoot, writable: true });
-    Object.defineProperty(wrapper.vm.$el, "updateComplete", { value: undefined, writable: true });
+    Object.defineProperty(wrapper.vm.$refs.textfield, "shadowRoot", { value: mockShadowRoot, writable: true });
+    Object.defineProperty(wrapper.vm.$refs.textfield, "updateComplete", { value: undefined, writable: true });
     wrapper.vm.$options.mounted.call(wrapper.vm);
     wrapper.vm.$options.mounted.call(wrapper.vm);
     expect(styleNodes.length).toBe(1);
     expect(styleNodes[0].className).toBe("line-height-patch");
     expect(styleNodes[0].textContent).toContain("line-height: normal");
+  });
+
+  test("injects patch after updateComplete resolves", async () => {
+    const styleNodes = [];
+    const mockShadowRoot = {
+      querySelector: () => styleNodes.find((n) => n.className === "line-height-patch") || null,
+      appendChild: (node) => styleNodes.push(node),
+    };
+    const wrapper = mount(InputVue, {
+      props: { question: { name: "test", answer: "", type: "input" } },
+      global: { stubs: vscodeStubs },
+    });
+    Object.defineProperty(wrapper.vm.$refs.textfield, "shadowRoot", { value: mockShadowRoot, writable: true });
+    Object.defineProperty(wrapper.vm.$refs.textfield, "updateComplete", { value: Promise.resolve(), writable: true });
+    wrapper.vm.$options.mounted.call(wrapper.vm);
+    await Promise.resolve();
+    expect(styleNodes.length).toBe(1);
+    expect(styleNodes[0].className).toBe("line-height-patch");
   });
 });

--- a/packages/inquirer-gui/__tests__/input.spec.js
+++ b/packages/inquirer-gui/__tests__/input.spec.js
@@ -1501,7 +1501,7 @@ describe("Questions of type input, password and number", () => {
   });
 });
 
-describe("applyPatch shadow DOM injection", () => {
+describe("mountLineHeightPatch shadow DOM injection", () => {
   test("injects exactly one style.line-height-patch and does not inject again on repeat calls", () => {
     const styleNodes = [];
     const mockShadowRoot = {

--- a/packages/inquirer-gui/__tests__/input.spec.js
+++ b/packages/inquirer-gui/__tests__/input.spec.js
@@ -1500,3 +1500,24 @@ describe("Questions of type input, password and number", () => {
     expect(component).toBe("CustomComponent");
   });
 });
+
+describe("applyPatch shadow DOM injection", () => {
+  test("injects exactly one style.line-height-patch and does not inject again on repeat calls", () => {
+    const styleNodes = [];
+    const mockShadowRoot = {
+      querySelector: () => styleNodes.find((n) => n.className === "line-height-patch") || null,
+      appendChild: (node) => styleNodes.push(node),
+    };
+    const wrapper = mount(InputVue, {
+      props: { question: { name: "test", answer: "", type: "input" } },
+      global: { stubs: vscodeStubs },
+    });
+    Object.defineProperty(wrapper.vm.$el, "shadowRoot", { value: mockShadowRoot, writable: true });
+    Object.defineProperty(wrapper.vm.$el, "updateComplete", { value: undefined, writable: true });
+    wrapper.vm.$options.mounted.call(wrapper.vm);
+    wrapper.vm.$options.mounted.call(wrapper.vm);
+    expect(styleNodes.length).toBe(1);
+    expect(styleNodes[0].className).toBe("line-height-patch");
+    expect(styleNodes[0].textContent).toContain("line-height: normal");
+  });
+});

--- a/packages/inquirer-gui/src/packages/QuestionInput.vue
+++ b/packages/inquirer-gui/src/packages/QuestionInput.vue
@@ -9,6 +9,9 @@
 </template>
 
 <script>
+// @vscode-elements/elements@1.11.0 hardcodes line-height: 18px on the inner
+// <input> with no CSS custom property hook. Remove this patch when the library
+// exposes one (e.g. --vscode-input-line-height).
 function applyPatch(el) {
   if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
     const style = document.createElement("style");
@@ -28,7 +31,7 @@ export default {
     if (el && typeof el.updateComplete !== "undefined") {
       el.updateComplete.then(() => applyPatch(el));
     } else {
-      applyPatch(el);
+      applyPatch(el); // fallback for non-Lit environments; usually a no-op in tests
     }
   },
   methods: {

--- a/packages/inquirer-gui/src/packages/QuestionInput.vue
+++ b/packages/inquirer-gui/src/packages/QuestionInput.vue
@@ -1,5 +1,6 @@
 <template>
   <vscode-textfield
+    ref="textfield"
     @input="onInput"
     :name="question.name"
     :value="question.answer"
@@ -9,7 +10,26 @@
 </template>
 
 <script>
-import { mountLineHeightPatch } from "../utils";
+// @vscode-elements/elements@1.11.0 hardcodes line-height: 18px on the inner
+// <input> with no CSS custom property hook. Remove this patch when the library
+// exposes one (e.g. --vscode-input-line-height).
+function applyPatch(el) {
+  if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
+    const style = document.createElement("style");
+    style.className = "line-height-patch";
+    // !important needed to override the library's hardcoded constructed stylesheet
+    style.textContent = "input { line-height: normal !important; }";
+    el.shadowRoot.appendChild(style);
+  }
+}
+
+function mountLineHeightPatch(el) {
+  if (el && typeof el.updateComplete !== "undefined") {
+    el.updateComplete.then(() => applyPatch(el));
+  } else {
+    applyPatch(el); // fallback for non-Lit environments; usually a no-op in tests
+  }
+}
 
 export default {
   name: "QuestionInput",
@@ -17,7 +37,7 @@ export default {
     question: Object,
   },
   mounted() {
-    mountLineHeightPatch(this.$el);
+    mountLineHeightPatch(this.$refs.textfield);
   },
   methods: {
     onInput(val) {

--- a/packages/inquirer-gui/src/packages/QuestionInput.vue
+++ b/packages/inquirer-gui/src/packages/QuestionInput.vue
@@ -9,10 +9,27 @@
 </template>
 
 <script>
+function applyPatch(el) {
+  if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
+    const style = document.createElement("style");
+    style.className = "line-height-patch";
+    style.textContent = "input { line-height: normal !important; }";
+    el.shadowRoot.appendChild(style);
+  }
+}
+
 export default {
   name: "QuestionInput",
   props: {
     question: Object,
+  },
+  mounted() {
+    const el = this.$el;
+    if (el && typeof el.updateComplete !== "undefined") {
+      el.updateComplete.then(() => applyPatch(el));
+    } else {
+      applyPatch(el);
+    }
   },
   methods: {
     onInput(val) {

--- a/packages/inquirer-gui/src/packages/QuestionInput.vue
+++ b/packages/inquirer-gui/src/packages/QuestionInput.vue
@@ -9,17 +9,7 @@
 </template>
 
 <script>
-// @vscode-elements/elements@1.11.0 hardcodes line-height: 18px on the inner
-// <input> with no CSS custom property hook. Remove this patch when the library
-// exposes one (e.g. --vscode-input-line-height).
-function applyPatch(el) {
-  if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
-    const style = document.createElement("style");
-    style.className = "line-height-patch";
-    style.textContent = "input { line-height: normal !important; }";
-    el.shadowRoot.appendChild(style);
-  }
-}
+import { mountLineHeightPatch } from "../utils";
 
 export default {
   name: "QuestionInput",
@@ -27,12 +17,7 @@ export default {
     question: Object,
   },
   mounted() {
-    const el = this.$el;
-    if (el && typeof el.updateComplete !== "undefined") {
-      el.updateComplete.then(() => applyPatch(el));
-    } else {
-      applyPatch(el); // fallback for non-Lit environments; usually a no-op in tests
-    }
+    mountLineHeightPatch(this.$el);
   },
   methods: {
     onInput(val) {

--- a/packages/inquirer-gui/src/utils.js
+++ b/packages/inquirer-gui/src/utils.js
@@ -1,3 +1,23 @@
+// @vscode-elements/elements@1.11.0 hardcodes line-height: 18px on the inner
+// <input> with no CSS custom property hook. Remove this patch when the library
+// exposes one (e.g. --vscode-input-line-height).
+function applyLineHeightPatch(el) {
+  if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
+    const style = document.createElement("style");
+    style.className = "line-height-patch";
+    style.textContent = "input { line-height: normal !important; }";
+    el.shadowRoot.appendChild(style);
+  }
+}
+
+export function mountLineHeightPatch(el) {
+  if (el && typeof el.updateComplete !== "undefined") {
+    el.updateComplete.then(() => applyLineHeightPatch(el));
+  } else {
+    applyLineHeightPatch(el); // fallback for non-Lit environments; usually a no-op in tests
+  }
+}
+
 export default {
   // roughly based on underscore.js:
   //   https://github.com/jashkenas/underscore/blob/1.9.2/underscore.js#L887

--- a/packages/inquirer-gui/src/utils.js
+++ b/packages/inquirer-gui/src/utils.js
@@ -1,23 +1,3 @@
-// @vscode-elements/elements@1.11.0 hardcodes line-height: 18px on the inner
-// <input> with no CSS custom property hook. Remove this patch when the library
-// exposes one (e.g. --vscode-input-line-height).
-function applyLineHeightPatch(el) {
-  if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
-    const style = document.createElement("style");
-    style.className = "line-height-patch";
-    style.textContent = "input { line-height: normal !important; }";
-    el.shadowRoot.appendChild(style);
-  }
-}
-
-export function mountLineHeightPatch(el) {
-  if (el && typeof el.updateComplete !== "undefined") {
-    el.updateComplete.then(() => applyLineHeightPatch(el));
-  } else {
-    applyLineHeightPatch(el); // fallback for non-Lit environments; usually a no-op in tests
-  }
-}
-
 export default {
   // roughly based on underscore.js:
   //   https://github.com/jashkenas/underscore/blob/1.9.2/underscore.js#L887

--- a/packages/login-plugin/src/packages/QuestionLogin.vue
+++ b/packages/login-plugin/src/packages/QuestionLogin.vue
@@ -19,16 +19,15 @@
 </template>
 
 <script>
-// TODO: separate login from answer
-//   @input should fire an answerChanged event
-//   icon@click should fire a custom doLogin event
-// This enables validating the password upon typing
-// It also enables providing specific feedback when actual login fails/succeeds
+import { mountLineHeightPatch } from "../../../inquirer-gui/src/utils";
 
 export default {
   name: "QuestionLogin",
   props: {
     question: Object,
+  },
+  mounted() {
+    mountLineHeightPatch(this.$el);
   },
   methods: {
     afterLogin() {

--- a/packages/login-plugin/src/packages/QuestionLogin.vue
+++ b/packages/login-plugin/src/packages/QuestionLogin.vue
@@ -21,6 +21,12 @@
 <script>
 import { mountLineHeightPatch } from "../../../inquirer-gui/src/utils";
 
+// TODO: separate login from answer
+//   @input should fire an answerChanged event
+//   icon@click should fire a custom doLogin event
+// This enables validating the password upon typing
+// It also enables providing specific feedback when actual login fails/succeeds
+
 export default {
   name: "QuestionLogin",
   props: {

--- a/packages/login-plugin/src/packages/QuestionLogin.vue
+++ b/packages/login-plugin/src/packages/QuestionLogin.vue
@@ -1,6 +1,6 @@
 <template>
   <vscode-textfield
-    ref="login"
+    ref="textfield"
     @keyup.enter="onLogin"
     @change="onInput"
     :name="question.name"
@@ -19,7 +19,26 @@
 </template>
 
 <script>
-import { mountLineHeightPatch } from "../../../inquirer-gui/src/utils";
+// @vscode-elements/elements@1.11.0 hardcodes line-height: 18px on the inner
+// <input> with no CSS custom property hook. Remove this patch when the library
+// exposes one (e.g. --vscode-input-line-height).
+function applyPatch(el) {
+  if (el && el.shadowRoot && !el.shadowRoot.querySelector("style.line-height-patch")) {
+    const style = document.createElement("style");
+    style.className = "line-height-patch";
+    // !important needed to override the library's hardcoded constructed stylesheet
+    style.textContent = "input { line-height: normal !important; }";
+    el.shadowRoot.appendChild(style);
+  }
+}
+
+function mountLineHeightPatch(el) {
+  if (el && typeof el.updateComplete !== "undefined") {
+    el.updateComplete.then(() => applyPatch(el));
+  } else {
+    applyPatch(el); // fallback for non-Lit environments; usually a no-op in tests
+  }
+}
 
 // TODO: separate login from answer
 //   @input should fire an answerChanged event
@@ -33,7 +52,7 @@ export default {
     question: Object,
   },
   mounted() {
-    mountLineHeightPatch(this.$el);
+    mountLineHeightPatch(this.$refs.textfield);
   },
   methods: {
     afterLogin() {


### PR DESCRIPTION
 ## Changes
  - Added `applyPatch` function in `QuestionInput.vue` that injects a `<style>` tag into the `vscode-textfield` shadow root on `mounted()`
  - The injected style overrides the hardcoded `line-height: 18px` on the inner `<input>` with `line-height: normal`, allowing the browser to calculate the natural line height for the active font

 ## Problem
 Text in `<vscode-textfield>` inputs was being clipped at the bottom on Windows (Segoe UI font). Characters with descenders (`g`, `y`, `p`, `q`, `j`) had their tails cut off. 

Root cause: `@vscode-elements/elements@1.11.0` hardcodes `line-height: 18px` on the inner `<input>`. At `16px` font size (set by `inquirer-gui`), Segoe UI descenders exceed this height and get clipped.

  ## Findings
  - **CSS custom property for `line-height`** — `@vscode-elements/elements` does not expose one; the only exposed properties are font family, size, weight, and colours
  - **Standard CSS from `globalStyles.css`** — does not work; CSS selectors cannot cross the shadow DOM boundary
  - **CSS custom properties** (`--design-unit`, `--base-height-multiplier`) — these belong to `@vscode/webview-ui-toolkit`, not `@vscode-elements/elements`. The library does not reference them internally so they have no effect
  - **`::part(input)`** — `@vscode-elements/elements` does not expose any `part` attributes on `vscode-textfield`, so this selector has nothing to target
  - **Setting `height`/`min-height` on the host element** — only resizes the outer wrapper; the inner `<input>` remains the same fixed size

 Since the component exposes no CSS custom property, no `::part()`, and the shadow DOM blocks external selectors, injecting a stylesheet directly into the shadow root was the only viable approach.